### PR TITLE
Fix link on https://feathericon.github.io/feathericon/

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -46,7 +46,7 @@
         </div>
         <nav class="l-nav">
           <ul class="menu">
-            <li><a href="/getting-started.html">Getting Started</a></li>
+            <li><a href="./getting-started.html">Getting Started</a></li>
             <li><a href="https://github.com/feathericon/feathericon/releases" target="_blank" rel="noopener">Releases</a></li>
             <li><a href="https://github.com/feathericon/feathericon" target="_blank" rel="noopener">GitHub</a></li>
             <li><a href="https://github.com/feathericon/feathericon/blob/master/LICENSE" target="_blank" rel="noopener">License</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         </div>
         <nav class="l-nav">
           <ul class="menu">
-            <li><a href="/getting-started.html">Getting Started</a></li>
+            <li><a href="./getting-started.html">Getting Started</a></li>
             <li><a href="https://github.com/feathericon/feathericon/releases" target="_blank" rel="noopener">Releases</a></li>
             <li><a href="https://github.com/feathericon/feathericon" target="_blank" rel="noopener">GitHub</a></li>
             <li><a href="https://github.com/feathericon/feathericon/blob/master/LICENSE" target="_blank" rel="noopener">License</a></li>


### PR DESCRIPTION
Hello!
I found an invalid link on https://feathericon.github.io/feathericon/ and I fixed it.

<img width="600" alt="Screen Shot 2021-02-28 at 1 43 43" src="https://user-images.githubusercontent.com/6269639/109393671-73b81100-7966-11eb-892f-80de69543230.png">
